### PR TITLE
Recover disable animation on tooltips

### DIFF
--- a/src/components/Tooltip/Tooltip/index.jsx
+++ b/src/components/Tooltip/Tooltip/index.jsx
@@ -20,7 +20,8 @@ type Props = {
   size?: 'small' | 'normal',
   targetAttachment?: Attachment,
   toggle?: (value: boolean) => () => void,
-  type: 'primary' | 'brand' | 'wrong' | 'negative' | 'popover'
+  type: 'primary' | 'brand' | 'wrong' | 'negative' | 'popover',
+  animated: boolean
 }
 
 const cx = classNames.bind(styles)
@@ -30,7 +31,8 @@ export default class Tooltip extends React.Component {
   mouseOver: boolean = false
 
   static defaultProps = {
-    size: 'normal'
+    size: 'normal',
+    animated: true
   }
 
   @autobind
@@ -54,14 +56,14 @@ export default class Tooltip extends React.Component {
   }
 
   renderTooltip () {
-    const { darkenArrow, open, children, type, size } = this.props
+    const { darkenArrow, open, children, type, size, animated } = this.props
 
     if (!open) return null
     if (!children) return null // flow
 
     return (
       <div
-        className={cx(type, 'tooltip', type, size)}
+        className={cx(type, 'tooltip', type, size, { animated })}
         onMouseOver={this.onMouseOver}
         onMouseLeave={this.onMouseLeave}
       >

--- a/src/components/Tooltip/Tooltip/index.scss
+++ b/src/components/Tooltip/Tooltip/index.scss
@@ -22,10 +22,13 @@
 
 .tooltip {
   font-family: $font-stack;
-  animation-duration: .2s;
-  animation-fill-mode: both;
-  animation-timing-function: cubic-bezier(0.175, 0.885, 0.320, 1.275);
   position: relative;
+
+  &.animated {
+    animation-duration: .2s;
+    animation-fill-mode: both;
+    animation-timing-function: cubic-bezier(0.175, 0.885, 0.320, 1.275);
+  }
 
   .content {
     position: relative;


### PR DESCRIPTION
## What?
Add a flag to tooltips to disable animation. This was a feature introduced before this component was moved to this repo but now is lost

